### PR TITLE
bugfix - registration sends no mails with umlauts in subject

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -7,6 +7,7 @@
 <head>
     <link rel="shortcut icon" href="<?php echo HOST_URL; ?>/favicon.ico" />
     <title><?php echo TCG_META_TITLE; ?></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="<?php echo TCG_META_TITLE; ?>" />
     <meta name="description" content="<?php echo TCG_META_DESC; ?>" />
     <meta name="keywords" content="<?php echo TCG_META_KEYWORDS; ?>" />

--- a/tcg/lostpassword.php
+++ b/tcg/lostpassword.php
@@ -34,7 +34,7 @@ if (isset($_POST['nickname']) && isset($_POST['email'])) {
             require_once('./inc/class.passwordhash_tcg.php');
             $password_hashed = create_hash_for_tcg($password);
 
-            mail($receiver, $subject, $text,
+            mail($receiver, mb_encode_mimeheader($subject,'UTF-8','Q'), $text,
                 "From: $sender <$sendermail>");
             mysqli_query($link, "UPDATE member SET member_password = '".$password_hashed."' WHERE member_nick = '".$nickname."' AND member_email = '".$email."' LIMIT 1") OR die(mysqli_error($link));
 

--- a/tcg/register.php
+++ b/tcg/register.php
@@ -68,7 +68,7 @@ if (isset($_POST['nickname'])) {
 
 '.TRANSLATIONS[$GLOBALS['language']]['general']['text_email_enclosure'];
 
-                mail($receiver, $subject, $text,
+                mail($receiver, mb_encode_mimeheader($subject,'UTF-8','Q'), $text,
                     "From: $sender <$sendermail>");
 
                 alert_box(TRANSLATIONS[$GLOBALS['language']]['register']['hint_success'], 'success');


### PR DESCRIPTION
- add utf8 meta tag
- use `mb_encode_mimeheader` for mail subjects